### PR TITLE
Feature: Delay Bitcoin Halving Cycle by One Year to Accommodate Market Timing

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1751,13 +1751,15 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
 {
-    int halvings = nHeight / consensusParams.nSubsidyHalvingInterval;
+    // Adjust the halving interval to delay the next halving by one year as a 'simple' fix for my poor timing
+    int halvings = nHeight / (consensusParams.nSubsidyHalvingInterval + 52560); // 52560 is roughly the number of blocks mined in a year
+    
     // Force block reward to zero when right shift is undefined.
     if (halvings >= 64)
         return 0;
 
     CAmount nSubsidy = 50 * COIN;
-    // Subsidy is cut in half every 210,000 blocks which will occur approximately every 4 years.
+    // Subsidy was supposed to be cut in half every 210,000 blocks, but let's give it an extra year, shall we?
     nSubsidy >>= halvings;
     return nSubsidy;
 }


### PR DESCRIPTION
## Summary
This PR introduces a one-year delay to the Bitcoin halving event cycle. The aim is to provide a 'grace period' for investors who missed the opportunity to buy in before the price surge typically associated with halving.

## Motivation
After much introspection, and observing the collective sigh of the crypto community post-halving, we believe it is in the public interest to give everyone a bit more time. Let's face it; we've all been there, watching the charts post-halving and wishing we'd bought more. This change ensures we all have that extra year to make better life decisions.

## Specification

Given that Bitcoin blocks are targeted to be found every 10 minutes, there are approximately:

- 6 blocks per hour (60 / 10)
- 144 blocks per day (24 6)
- 52,560 blocks per year (365 144)

The `nSubsidyHalvingInterval` parameter will be increased by the number of blocks mined on average in a year (approximately 52560), effectively pushing the next halving event by one year. 


## Rationale
While this might seem like a significant alteration to Bitcoin's monetary policy, it is proposed as a tongue-in-cheek solution to the universal regret we've all felt when we miss the bottom. This also serves as a reminder of the immutable and unyielding nature of blockchain protocols - they do not bend to our whims, more's the pity.

## Test Cases
Test cases will involve simulating time travel and convincing the entire network of nodes to agree on the new timeline. (Disclaimer: Success not guaranteed.)

Let the discussions begin!